### PR TITLE
ISLANDORA-364

### DIFF
--- a/islandora_book.module
+++ b/islandora_book.module
@@ -288,7 +288,7 @@ function islandora_book_required_fedora_objects() {
           'dsversion' => NULL,
         ),
         array(
-          'foxml_file' => "$module_path/xml/islandora_book_jp2sdef.xml",
+          'foxml_file' => "$module_path/xml/islandora_book_jp2Sdef.xml",
           'pid' => 'islandora:jp2Sdef',
           'dsid' => NULL,
           'datastream_file' => NULL,


### PR DESCRIPTION
This is a one character typo fix. The typo prevents the loading of a foxml from a file.
