### PR TITLE
6.x

### DIFF
--- a/imt.inc
+++ b/imt.inc
@@ -27,7 +27,7 @@ class IMTViewer {
     $htmlstr = preg_replace('/Image" src="([^"]+)"/', $pstring, $htmlstr);
     $htmlstr = preg_replace('/<\/body><\/html>/', '', $htmlstr);
     $htmlstr = preg_replace('/<\?xml(.*?)head>/s', '', $htmlstr);
-    if (!$htmlstr){
+    if (!$htmlstr) {
       $htmlstr = '<div><div><a href="' . $base_url . '/fedora/repository/' . $this->pid . '/JPEG/">View Full Size</a></div>' .
       '<div><a href="' . $base_url . '/fedora/repository/' . $this->pid . '/JPEG/"><img src="' .
       $base_url . '/fedora/repository/' . $this->pid . '/JPEG/' . '" /></a></div>';

--- a/islandora_book.admin.inc
+++ b/islandora_book.admin.inc
@@ -37,7 +37,7 @@ function islandora_book_admin_settings(&$form_state) {
 
   $form['book_ahah_wrapper']['islandora_book_create_images'] = array(
     '#type' => 'checkbox',
-    '#title' => t('Create derivative images locally ?'),
+    '#title' => t('Create derivative images locally?'),
     '#description' => t('Leave this box checked unless processing of images is done on an external server.'),
     '#default_value' => variable_get('islandora_book_create_images', TRUE),
   );
@@ -52,6 +52,12 @@ function islandora_book_admin_settings(&$form_state) {
       'wrapper' => 'ibook-url',
       'effect' => 'fade',
       'event' => 'change'),
+  );
+  $form['book_ahah_wrapper']['islandora_book_solr_subject_field'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Solr subject field'),
+    '#description' => t('The solr field containing your untokenized subject value, used to link between books with the same subject.'),
+    '#default_value' => variable_get('islandora_book_solr_subject_field', ''),
   );
   if ($ocr) {
     $form['book_ahah_wrapper']['islandora_ocr_path'] = array(

--- a/islandora_book.admin.inc
+++ b/islandora_book.admin.inc
@@ -57,7 +57,8 @@ function islandora_book_admin_settings(&$form_state) {
     '#type' => 'textfield',
     '#title' => t('Solr subject field'),
     '#description' => t('The solr field containing your untokenized subject value, used to link between books with the same subject.'),
-    '#default_value' => variable_get('islandora_book_solr_subject_field', ''),
+    // keep default value as previous default so its backward compatible
+    '#default_value' => variable_get('islandora_book_solr_subject_field', 'mods.subject'),
   );
   if ($ocr) {
     $form['book_ahah_wrapper']['islandora_ocr_path'] = array(

--- a/islandora_book.module
+++ b/islandora_book.module
@@ -165,7 +165,7 @@ function islandora_book_create_book_view($pid, $query = NULL) {
     'OBJECTSPAGE' => base_path(),
     'PID' => $pid,
     'INGESTED' => $ingested,
-    'SOLRFIELD' => variable_get('islandora_book_solr_subject_field', ''),
+    'SOLRFIELD' => variable_get('islandora_book_solr_subject_field', 'mods.subject'),
   );
   $proc->setParameter("", $params);
   $xsl = new DomDocument();
@@ -185,7 +185,6 @@ function islandora_book_create_book_view($pid, $query = NULL) {
   else {
     $xsl = $proc->importStylesheet($xsl);
     $output = $proc->transformToXML($input);
-    //$output .= $newdom->saveXML();
   }
   if (isset($query)) {
     module_load_include('inc', 'fedora_repository', 'core/SearchClass');

--- a/islandora_book.module
+++ b/islandora_book.module
@@ -96,7 +96,7 @@ function disabled_islandora_book_init() {
 
 /**
  * Islandora book book viewer
- * Allows viweing of book object thorugh embedded player
+ * Allows viewing of book object thorugh embedded player
  * @global user $user
  * @param string $pid
  * @return html
@@ -129,9 +129,9 @@ function islandora_book_create_book_view($pid, $query = NULL) {
   global $user;
   module_load_include('inc', 'fedora_repository', 'api/ObjectHelper');
   $path = drupal_get_path('module', 'islandora_book');
-  $objectHelper = new ObjectHelper;
-  $xml = $objectHelper->getStream($pid, 'MODS');
-  $dc_xml = $objectHelper->getStream($pid, 'DC');
+  $object_helper = new ObjectHelper;
+  $xml = $object_helper->getStream($pid, 'MODS');
+  $dc_xml = $object_helper->getStream($pid, 'DC');
   if (!$dc_xml) {
     drupal_set_message(t('Object does not exist.'), 'error');
     return '';
@@ -155,15 +155,19 @@ function islandora_book_create_book_view($pid, $query = NULL) {
   try {
     $proc = new XsltProcessor();
   } catch (Exception $e) {
-    drupal_set_message(t('Error loading Book View XSLT: $e', array('@e' => check_plain($e->getMessage()))));
+    drupal_set_message(t('Error loading Book View XSLT: @e', array('@e' => check_plain($e->getMessage()))));
     return;
   }
 
   //inject into xsl stylesheet
-  $proc->setParameter('', 'userID', $user->uid);
-  $proc->setParameter('', 'objectsPage', base_path());
-  $proc->setParameter('', 'pid', $pid);
-  $proc->setParameter('', 'ingested', $ingested);
+  $params = array(
+    'USERID' => $user->uid,
+    'OBJECTSPAGE' => base_path(),
+    'PID' => $pid,
+    'INGESTED' => $ingested,
+    'SOLRFIELD' => variable_get('islandora_book_solr_subject_field', ''),
+  );
+  $proc->setParameter("", $params);
   $xsl = new DomDocument();
   $test = $xsl->load($path . '/xsl/book_view.xsl');
   if (!isset($test)) {
@@ -180,8 +184,8 @@ function islandora_book_create_book_view($pid, $query = NULL) {
   }
   else {
     $xsl = $proc->importStylesheet($xsl);
-    $newdom = $proc->transformToDoc($input);
-    $output .= $newdom->saveXML();
+    $output = $proc->transformToXML($input);
+    //$output .= $newdom->saveXML();
   }
   if (isset($query)) {
     module_load_include('inc', 'fedora_repository', 'core/SearchClass');
@@ -189,12 +193,8 @@ function islandora_book_create_book_view($pid, $query = NULL) {
     $pageQuery = convert_query_to_page_query($query, $pid);
     $output .= '<div>' . $searchClass->custom_search($pageQuery, $startPage, '/xsl/pageResults.xsl', 500) . '</div>'; //limit results to 500 pages of a book since there is no paging if we enable paging in xslt this can be changed
     //return $output."<div>used this query to find this page $query and new query = $pageQuery</div>";
-
-    return $output;
   }
-  else {
-    return $output;
-  }
+  return $output;
 }
 
 /**

--- a/page_object_manager.inc
+++ b/page_object_manager.inc
@@ -50,7 +50,7 @@ function page_management_form(&$form_state, $pid) {
     '#type' => 'fieldset',
     '#collapsed' => TRUE,
     '#collapsible' => TRUE,
-    '#title' => t('Update Derivations'),
+    '#title' => t('Update Derived Datastreams'),
     '#description' => t('Update datastreams for this page object.  The orginal stored tiff will be used to create all derived datastreams.'),
   );
   $form['page_manage']['do_ocr'] = array(

--- a/page_object_manager.inc
+++ b/page_object_manager.inc
@@ -71,7 +71,7 @@ function page_management_form(&$form_state, $pid) {
     '#type' => 'fieldset',
     '#collapsed' => TRUE,
     '#collapsible' => TRUE,
-    '#title' => t('Current Datastreams'),
+    '#title' => t('Manage Current Datastreams'),
   );
 
   $form['current_datastreams']['current_object_details'] = array(

--- a/page_object_manager.inc
+++ b/page_object_manager.inc
@@ -15,7 +15,6 @@ function get_page_model_management_content($pid) {
   return $form;
 }
 
-
 function page_management_form(&$form_state, $pid) {
   if (!user_access('manage page object')) {
     return;
@@ -23,10 +22,10 @@ function page_management_form(&$form_state, $pid) {
   module_load_include('inc', 'islandora_book', 'book_pack_utils');
   module_load_include('inc', 'fedora_repository', 'plugins/FedoraObjectDetailedContent');
   $content_helper = new FedoraObjectDetailedContent($pid);
-  $objectHelper = new ObjectHelper();
+  $object_helper = new ObjectHelper();
   $ds_list = datastream_display_builder($content_helper->pid, $content_helper->item);
   $add_datastreams_details = get_add_datastream_data($content_helper->pid);
-  $dc_html = $objectHelper->getFormattedDC($content_helper->item);
+  $dc_html = $object_helper->getFormattedDC($content_helper->item);
   $purge_form = drupal_get_form('fedora_repository_purge_object_form', $content_helper->pid, check_plain(substr(request_uri(), strlen(base_path()))));
   $form = array();
   $form['pid'] = array(
@@ -37,8 +36,8 @@ function page_management_form(&$form_state, $pid) {
 
   $form['view_dc'] = array(
     '#type' => 'fieldset',
-    '#collapsed' => true,
-    '#collapsible' => true,
+    '#collapsed' => TRUE,
+    '#collapsible' => TRUE,
     '#title' => t('View Metadata'),
   );
 
@@ -49,9 +48,9 @@ function page_management_form(&$form_state, $pid) {
   );
   $form['page_manage'] = array(
     '#type' => 'fieldset',
-    '#collapsed' => true,
-    '#collapsible' => true,
-    '#title' => t('Update Derived Datastreams'),
+    '#collapsed' => TRUE,
+    '#collapsible' => TRUE,
+    '#title' => t('Update Derivations'),
     '#description' => t('Update datastreams for this page object.  The orginal stored tiff will be used to create all derived datastreams.'),
   );
   $form['page_manage']['do_ocr'] = array(
@@ -70,9 +69,9 @@ function page_management_form(&$form_state, $pid) {
   );
   $form['current_datastreams'] = array(
     '#type' => 'fieldset',
-    '#collapsed' => true,
-    '#collapsible' => true,
-    '#title' => t('Manage Current Datastreams'),
+    '#collapsed' => TRUE,
+    '#collapsible' => TRUE,
+    '#title' => t('Current Datastreams'),
   );
 
   $form['current_datastreams']['current_object_details'] = array(
@@ -82,8 +81,8 @@ function page_management_form(&$form_state, $pid) {
   );
   $form['add_datastreams'] = array(
     '#type' => 'fieldset',
-    '#collapsed' => true,
-    '#collapsible' => true,
+    '#collapsed' => TRUE,
+    '#collapsible' => TRUE,
     '#title' => t('Add Additional Datastreams'),
   );
   if (count($add_datastreams_details) > 0) {

--- a/xsl/book_view.xsl
+++ b/xsl/book_view.xsl
@@ -1,56 +1,95 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" xmlns:mods="http://www.loc.gov/mods/v3">
-    <xsl:variable name="OBJECTSPAGE">
-		 	<xsl:value-of select="$objectsPage"/>
-</xsl:variable>
-    <xsl:variable name="PID">
-		 	<xsl:value-of select="$pid"/>
-</xsl:variable>
-<xsl:variable name="RECORDID">
-  <xsl:value-of select='substring-after($PID,":")'/>
-</xsl:variable>
- <xsl:variable name="USER" select="$userID"/>
- <xsl:variable name="INGESTED" select="$ingested"/>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" xmlns:mods="http://www.loc.gov/mods/v3" xmlns:php="http://php.net/xsl">
+  <xsl:param name="OBJECTSPAGE"/>
+  <xsl:param name="PID"/>
+  <xsl:param name="USER"/>
+  <xsl:param name="INGESTED"/>
+  <xsl:param name="SOLRFIELD"/>
 
- <xsl:template match="/">
+  <xsl:template match="/">
 
-<div id="islandora-book-view">
-    <table class="islandora-book-table"><tr><td >
-       <img>
-				<xsl:attribute name="src"><xsl:copy-of select="$OBJECTSPAGE"/>fedora/repository/<xsl:copy-of select="$PID"/>/TN
-				</xsl:attribute>
-			</img>
-
-
-
-   </td><td ><div style="align:left"><table class="islandora-book-table" cellpadding="3" cellspacing="2" width="90%" >
-  <tr><td align="right" valign="top"><b>By Statement: </b></td><td valign="top"><xsl:value-of select="//mods:note[@type='statement of responsibility']"/></td></tr>
-   <tr><td align="right" valign="top"><b>Place of Publication: </b></td ><td valign="top"><xsl:value-of select="//mods:placeTerm[@type='text']"/></td></tr>
-    <tr><td align="right" valign="top"><b>Publisher: </b></td><td valign="top"><xsl:value-of select="//mods:publisher"/></td></tr>
-    <tr><td align="right" valign="top"><b>Date: </b></td><td valign="top"><xsl:value-of select="//mods:dateIssued"/></td></tr>
-    <tr><td align="right" valign="top"><b>Language: </b></td><td valign="top"><xsl:value-of select="//mods:languageTerm"/></td></tr>
-    <tr><td align="right" valign="top"><b>Pagination: </b></td><td valign="top"><xsl:value-of select="//mods:extent"/></td></tr>
-    <tr><td align="right" valign="top"><b>ISBN 10: </b></td><td valign="top"><xsl:value-of select="//mods:identifier[@type='isbn']"/></td></tr>
-    <tr><td align="right" valign="top"><b>Subjects: </b></td><td valign="top"><xsl:for-each select="//mods:subject">
-                                <xsl:for-each select="*"> 
-                                <a><xsl:attribute name="href"><xsl:copy-of select="$OBJECTSPAGE"/>islandora/solr/search/mods.subject:"<xsl:value-of select="normalize-space(.)"/>"%20AND%20dc.type:collection%20AND%20dc.type:ingested
-				</xsl:attribute>
-                                    
-                                    <xsl:value-of select="."/></a><xsl:text> </xsl:text></xsl:for-each><br /></xsl:for-each>
-                               </td></tr>
-</table></div></td><td valign="top">
-  <xsl:if test="$INGESTED = 'true'">
-<div><a><xsl:attribute name="href"><xsl:copy-of select="$OBJECTSPAGE"/>fedora/book_viewer/<xsl:value-of select="$PID"/></xsl:attribute>Read</a>
-</div></xsl:if>
- <xsl:if test="$INGESTED = 'true'"><div>
-<a><xsl:attribute name="href"><xsl:copy-of select="$OBJECTSPAGE"/>fedora/repository/<xsl:value-of select="$PID"/>/PDF/<xsl:value-of select="$PID"/>.pdf</xsl:attribute>Download</a>
-</div></xsl:if>
-<xsl:if test="($USER > 0) and ($INGESTED = 'true')">
-<div>
-<a><xsl:attribute name="href"><xsl:copy-of select="$OBJECTSPAGE"/>teieditor/<xsl:value-of select="$PID"/></xsl:attribute>Edit</a>
-</div>
-</xsl:if>
-</td></tr></table>
-</div>
- </xsl:template>
+    <div id="islandora-book-view">
+      <table class="islandora-book-table">
+        <tr><td>
+          <img>
+            <xsl:attribute name="src"><xsl:copy-of select="$OBJECTSPAGE"/>fedora/repository/<xsl:copy-of select="$PID"/>/TN
+            </xsl:attribute>
+          </img>
+        </td>
+        <td>
+          <div style="align:left">
+            <table class="islandora-book-table" cellpadding="3" cellspacing="2" width="90%">
+              <tr>
+                <xsl:if test="//mods:note[@type='statement of responsibility']">
+                  <td align="right" valign="top"><b>By Statement: </b></td>
+                  <td valign="top"><xsl:value-of select="//mods:note[@type='statement of responsibility']"/></td>
+                </xsl:if>
+              </tr>
+              <tr>
+                <xsl:if test="//mods:placeTerm[@type='text']">
+                  <td align="right" valign="top"><b>Place of Publication: </b></td>
+                  <td valign="top"><xsl:value-of select="//mods:placeTerm[@type='text']"/></td>
+                </xsl:if>
+              </tr>
+              <tr>
+                <xsl:if test="//mods:publisher">
+                  <td align="right" valign="top"><b>Publisher: </b></td>
+                  <td valign="top"><xsl:value-of select="//mods:publisher"/></td>
+                </xsl:if>
+              </tr>
+              <tr>
+                <xsl:if test="//mods:dateIssued">
+                  <td align="right" valign="top"><b>Date: </b></td>
+                  <td valign="top"><xsl:value-of select="//mods:dateIssued"/></td>
+                </xsl:if>
+              </tr>
+              <tr>
+                <xsl:if test="//mods:languageTerm">
+                  <td align="right" valign="top"><b>Language: </b></td>
+                  <td valign="top"><xsl:value-of select="//mods:languageTerm"/></td>
+                </xsl:if>
+              </tr>
+              <tr>
+                <xsl:if test="//mods:extent">
+                  <td align="right" valign="top"><b>Pagination: </b></td>
+                  <td valign="top"><xsl:value-of select="//mods:extent"/></td>
+                </xsl:if>
+              </tr>
+              <tr>
+                <xsl:if test="//mods:identifier[@type='isbn']">
+                  <td align="right" valign="top"><b>ISBN 10: </b></td>
+                  <td valign="top"><xsl:value-of select="//mods:identifier[@type='isbn']"/></td>
+                </xsl:if>
+              </tr>
+              <tr>
+                <xsl:if test="//mods:subject">
+                  <td align="right" valign="top"><b>Subjects: </b></td>
+                  <td valign="top">
+                    <xsl:for-each select="//mods:subject">
+                      <xsl:for-each select="*">
+                        <a><xsl:attribute name="href"><xsl:copy-of select="$OBJECTSPAGE"/>islandora/solr/search/<xsl:value-of select="$SOLRFIELD"/>:"<xsl:value-of select="normalize-space(.)"/>"</xsl:attribute><xsl:value-of select="."/></a>
+                        <xsl:text> </xsl:text>
+                      </xsl:for-each>
+                      <br />
+                    </xsl:for-each>
+                  </td>
+                </xsl:if>
+              </tr>
+            </table>
+          </div>
+        </td>
+        <td valign="top">
+          <xsl:if test="$INGESTED = 'true'">
+            <div><a><xsl:attribute name="href"><xsl:copy-of select="$OBJECTSPAGE"/>fedora/book_viewer/<xsl:value-of select="$PID"/></xsl:attribute>Read</a></div>
+          </xsl:if>
+          <xsl:if test="$INGESTED = 'true'">
+            <div><a><xsl:attribute name="href"><xsl:copy-of select="$OBJECTSPAGE"/>fedora/repository/<xsl:value-of select="$PID"/>/PDF/<xsl:value-of select="$PID"/>.pdf</xsl:attribute>Download</a></div>
+          </xsl:if>
+          <xsl:if test="($USER > 0) and ($INGESTED = 'true')">
+            <div><a><xsl:attribute name="href"><xsl:copy-of select="$OBJECTSPAGE"/>teieditor/<xsl:value-of select="$PID"/></xsl:attribute>Edit</a></div>
+          </xsl:if>
+        </td></tr>
+      </table>
+    </div>
+  </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
The guys at pittsburgh noticed that the book's description page was (a) metadata values when they were empty and (b) failing to construct links for the subjects.  The links could not be created because the solution pack was supplying the xslt with the wrong information to construct them.  I added a configuration option to the solution pack admin page and now it has the name of the solr field to connect objects with and it links to correct search results.
