### PR TITLE
7.x islandora solution pack book 1880

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: php
 php:
   - 5.3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ before_install:
   - drush en --user=1 --yes islandora_ocr islandora_large_image imagemagick islandora_book islandora_basic_collection
   - drush vset islandora_ocr_tesseract `which tesseract`
   - drush vset islandora_book_tesseract `which tesseract`
+before_script:
+  # Mysql might time out for long tests, increase the wait timeout.
+  - mysql -e 'SET @@GLOBAL.wait_timeout=1200'
 script:
   - ant -buildfile sites/all/modules/islandora_solution_pack_book/build.xml lint
   - $ISLANDORA_DIR/tests/scripts/line_endings.sh sites/all/modules/islandora_solution_pack_book

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,6 @@ script:
   - $ISLANDORA_DIR/tests/scripts/line_endings.sh sites/all/modules/islandora_solution_pack_book
   - drush coder-review --reviews=production,security,style,i18n,potx,sniffer islandora_book
   - phpcpd --names *.module,*.inc,*.test sites/all/modules/islandora_solution_pack_book
-  - drush test-run --user=1 --uri=http://localhost:8081 "Islandora Book"
+  - php scripts/run-tests.sh --php `phpenv which php` --url http://localhost:8081 --verbose "Islandora Book"
 notifications:
   irc: "irc.freenode.org#islandora"


### PR DESCRIPTION
JIRA Ticket: https://jira.duraspace.org/browse/ISLANDORA-1880

What does this Pull Request do?

Replaces Travis-CI Drupal Test invocations made via Drush, which are being deprecated, with Drupal's provided PHP scripts. Updates the YAML to have a MySQL timeout so that long running tests don't cause the MySQL session to timeout. Lastly, adds sudo for the YAML as old builds were grandfathered.

What's new?

Modified the .travis.yml file from Drush to the drupal script. Added Sudo in .travis.yml file as it required for the scrips to run, repos before 2015 were grandfathered in. However, this isn't the case for forks. Also, added a before_script in travis.yml file to extend mysql wait time to 1200 as the builds were failing in Travic-ci.org.

Interested parties

@Islandora/7-x-1-x-committers