### PR TITLE
ISLANDORA-1969 - Show page level metadata on page screen

### DIFF
--- a/islandora_book.module
+++ b/islandora_book.module
@@ -192,7 +192,9 @@ function islandora_book_islandora_bookcmodel_islandora_view_object($object) {
  * Implements hook_CMODEL_PID_islandora_view_object().
  */
 function islandora_book_islandora_pagecmodel_islandora_view_object($object, $page_number, $page_size) {
-  $output = theme('islandora_book_page', array('object' => $object));
+  module_load_include('inc', 'islandora', 'includes/metadata');
+  $metadata = islandora_retrieve_metadata_markup($object, TRUE);
+  $output = theme('islandora_book_page', array('object' => $object, 'metadata' => $metadata));
   return array('islandora_book' => $output);
 }
 

--- a/theme/islandora-book-page.tpl.php
+++ b/theme/islandora-book-page.tpl.php
@@ -22,4 +22,7 @@
     ?>
   </div>
 <?php endif; ?>
+<div class="islandora-book-metadata">
+  <?php print $metadata; ?>
+</div>
 <!-- @todo Add table of metadata values -->

--- a/theme/islandora-book-page.tpl.php
+++ b/theme/islandora-book-page.tpl.php
@@ -25,4 +25,3 @@
 <div class="islandora-book-metadata">
   <?php print $metadata; ?>
 </div>
-<!-- @todo Add table of metadata values -->


### PR DESCRIPTION
**JIRA Ticket**: 

https://jira.duraspace.org/browse/ISLANDORA-1969

# What does this Pull Request do?

Show page level metadata when navigating to the page view of a book

# What's new?

Places the metadata in the response and shows metadata on the template

# How should this be tested?

Navigate to page to see metadata

# Additional Notes:

None
