### PR TITLE
add ocr/hocr ignore options

### DIFF
--- a/includes/manage_book.inc
+++ b/includes/manage_book.inc
@@ -64,28 +64,29 @@ function islandora_book_ingest_zipped_pages(AbstractObject $object) {
  *   Drupal form definition.
  */
 function islandora_book_zipped_upload_form(array $form, array &$form_state, $book_pid) {
-  module_load_include('inc', 'islandora_ocr', 'includes/utilities');
   module_load_include('inc', 'islandora_paged_content', 'includes/utilities');
   $book_object = islandora_object_load($book_pid);
   $current_pages = islandora_paged_content_get_pages($book_object);
   $last_page_number = count($current_pages);
-  $languages = module_exists('islandora_ocr') ? islandora_ocr_get_enabled_tesseract_languages() : array();
   $upload_size = min((int) ini_get('post_max_size'), (int) ini_get('upload_max_filesize'));
   $extensions = array('zip');
   $form = array();
   $derivatives = variable_get('islandora_book_ingest_derivatives', array('ocr'));
-  $do_ocr = in_array('ocr', $derivatives);
   $message = t("This sequence currently has @count pages. Additional pages will be appended to the end of the sequence by default. !break", array("@count" => $last_page_number, '!break' => '<br />'));
   $message .= t("Choose a number lower than @count to insert page(s) at a specific location in the sequence.", array("@count" => $last_page_number, '!break' => '<br />'));
 
-  $form['language'] = array(
-    '#access' => module_exists('islandora_ocr') && $do_ocr,
-    '#title' => t('Language'),
-    '#type' => 'select',
-    '#description' => t('Please select the language the page is written in.'),
-    '#options' => $languages,
-    '#default_value' => 'English',
-  );
+  if (module_exists('islandora_ocr') && in_array('ocr', $derivatives)) {
+    module_load_include('inc', 'islandora_ocr', 'includes/utilities');
+    $form['language'] = array(
+      '#access' => module_exists('islandora_ocr') && $do_ocr,
+      '#title' => t('Language'),
+      '#type' => 'select',
+      '#description' => t('Please select the language the page is written in.'),
+      '#options' => islandora_ocr_get_enabled_tesseract_languages(),
+      '#default_value' => 'English',
+    );
+    $form['ignored_ocr_derivatives'] = islandora_ocr_get_ignored_derivatives_fieldset();
+  }
 
   if ($current_pages) {
     $form['insertion_point'] = array(
@@ -226,6 +227,10 @@ function islandora_book_zipped_upload_form_submit(array $form, array &$form_stat
       'destination_dir' => $destination_dir,
       'namespace' => $namespace,
       'language' => $form_state['values']['language'],
+      'ignored_derivs' => array(
+        'ocr' => $form_state['values']['ignore_ocr'],
+        'hocr' => $form_state['values']['ignore_hocr'],
+      ),
     );
     $offset = count($files_to_add);
     if (isset($pages_to_renumber[0])) {
@@ -276,6 +281,12 @@ function islandora_book_add_pages($repository, $config, $pages_directory, &$cont
   $rels_ext = $object->relationships;
   $parent = $config['book_pid'];
   $object->relationships->add(FEDORA_MODEL_URI, 'hasModel', 'islandora:pageCModel');
+  if ($config['ignored_derivs']['ocr']) {
+    islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'generate_ocr', 'FALSE', TRUE);
+  }
+  if ($config['ignored_derivs']['hocr']) {
+    islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'generate_hocr', 'FALSE', TRUE);
+  }
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isPageOf', $parent);
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isSequenceNumber', (string) $config['page_number'], TRUE);
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isPageNumber', (string) $config['page_number'], TRUE);

--- a/includes/manage_book.inc
+++ b/includes/manage_book.inc
@@ -226,10 +226,10 @@ function islandora_book_zipped_upload_form_submit(array $form, array &$form_stat
       'book_pid' => $book_pid,
       'destination_dir' => $destination_dir,
       'namespace' => $namespace,
-      'language' => $form_state['values']['language'],
+      'language' => isset($form_state['values']['language']) ? $form_state['values']['language'] : 'English',
       'ignored_derivs' => array(
-        'ocr' => $form_state['values']['ignore_ocr'],
-        'hocr' => $form_state['values']['ignore_hocr'],
+        'ocr' => isset($form_state['values']['ignore_ocr']) ? $form_state['values']['ignore_ocr'] : FALSE,
+        'hocr' => isset($form_state['values']['ignore_hocr']) ? $form_state['values']['ignore_hocr'] : FALSE,
       ),
     );
     $offset = count($files_to_add);

--- a/includes/manage_book.inc
+++ b/includes/manage_book.inc
@@ -281,11 +281,9 @@ function islandora_book_add_pages($repository, $config, $pages_directory, &$cont
   $rels_ext = $object->relationships;
   $parent = $config['book_pid'];
   $object->relationships->add(FEDORA_MODEL_URI, 'hasModel', 'islandora:pageCModel');
-  if ($config['ignored_derivs']['ocr']) {
-    islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'generate_ocr', 'FALSE', TRUE);
-  }
-  if ($config['ignored_derivs']['hocr']) {
-    islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'generate_hocr', 'FALSE', TRUE);
+  if (module_exists('islandora_ocr')) {
+    module_load_include('inc', 'islandora_ocr', 'includes/derivatives');
+    islandora_ocr_set_generating_rels_ext_statements($object, !$config['ignored_derivs']['ocr'], !$config['ignored_derivs']['hocr']);
   }
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isPageOf', $parent);
   islandora_paged_content_set_relationship($rels_ext, ISLANDORA_RELS_EXT_URI, 'isSequenceNumber', (string) $config['page_number'], TRUE);

--- a/includes/manage_book.inc
+++ b/includes/manage_book.inc
@@ -82,7 +82,7 @@ function islandora_book_zipped_upload_form(array $form, array &$form_state, $boo
       '#type' => 'select',
       '#description' => t('Please select the language the page is written in.'),
       '#options' => islandora_ocr_get_enabled_tesseract_languages(),
-      '#default_value' => 'English',
+      '#default_value' => 'eng',
     );
     $form['ignored_ocr_derivatives'] = islandora_ocr_get_ignored_derivatives_fieldset();
   }
@@ -225,7 +225,7 @@ function islandora_book_zipped_upload_form_submit(array $form, array &$form_stat
       'book_pid' => $book_pid,
       'destination_dir' => $destination_dir,
       'namespace' => $namespace,
-      'language' => isset($form_state['values']['language']) ? $form_state['values']['language'] : 'English',
+      'language' => isset($form_state['values']['language']) ? $form_state['values']['language'] : 'eng',
       'ignored_derivs' => array(
         'ocr' => isset($form_state['values']['ignore_ocr']) ? $form_state['values']['ignore_ocr'] : FALSE,
         'hocr' => isset($form_state['values']['ignore_hocr']) ? $form_state['values']['ignore_hocr'] : FALSE,

--- a/includes/manage_book.inc
+++ b/includes/manage_book.inc
@@ -78,7 +78,6 @@ function islandora_book_zipped_upload_form(array $form, array &$form_state, $boo
   if (module_exists('islandora_ocr') && in_array('ocr', $derivatives)) {
     module_load_include('inc', 'islandora_ocr', 'includes/utilities');
     $form['language'] = array(
-      '#access' => module_exists('islandora_ocr') && $do_ocr,
       '#title' => t('Language'),
       '#type' => 'select',
       '#description' => t('Please select the language the page is written in.'),


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2012

* Other Relevant Links: Hard requirement reliance on https://github.com/Islandora/islandora_ocr/pull/81

# What does this Pull Request do?
Adds the ability to ignore OCR/HOCR derivative generation when batch ingesting pages into books

# What's new?
When adding zipped pages to a book, the ability to opt-out of OCR/HOCR derivative generation has been added.

# How should this be tested?
Add zipped pages to a book; check off any set of the opt-out options for OCR/HOCR. These derivatives should not be generated.

# Interested parties
Maintained by @DiegoPino but linked to other PRs with other folks pinged.
