### PR TITLE
Work on ISLANDORA-2014.

### DIFF
--- a/islandora_book.module
+++ b/islandora_book.module
@@ -199,45 +199,6 @@ function islandora_book_islandora_pagecmodel_islandora_view_object($object, $pag
 /**
  * Implements hook_CMODEL_PID_islandora_solr_object_result_alter().
  *
- * Replaces the url for the search result to be the book's url, not the page.
- * The page is added as a fragment at the end of the book url.
- */
-function islandora_book_islandora_pageCModel_islandora_solr_object_result_alter(&$search_results, $query_processor) {
-  // Grab the names of the appropriate solr fields from the db.
-  $parent_book_field_name = variable_get('islandora_book_parent_book_solr_field', 'RELS_EXT_isMemberOf_uri_ms');
-  $page_number_field_name = variable_get('islandora_paged_content_page_number_solr_field', 'RELS_EXT_isSequenceNumber_literal_ms');
-  // If:
-  // there's an object url AND
-  // there's a solr doc AND
-  // the solr doc contains the parent book AND
-  // the solr doc contains the page number...
-  if (isset($search_results['object_url']) &&
-      isset($search_results['solr_doc']) &&
-      isset($search_results['solr_doc'][$parent_book_field_name]) &&
-      count($search_results['solr_doc'][$parent_book_field_name]) &&
-      isset($search_results['solr_doc'][$page_number_field_name]) &&
-      count($search_results['solr_doc'][$page_number_field_name])) {
-    // Replace the result url with that of the parent book and add the page
-    // number as a fragment.
-    $book_pid = preg_replace('/info\:fedora\//', '', $search_results['solr_doc'][$parent_book_field_name][0], 1);
-    $page_number = $search_results['solr_doc'][$page_number_field_name][0];
-
-    if (islandora_object_access(ISLANDORA_VIEW_OBJECTS, islandora_object_load($book_pid))) {
-      $search_results['object_url'] = "islandora/object/$book_pid";
-      $search_results['object_url_fragment'] = "page/$page_number/mode/1up";
-
-      // XXX: Won't handle fielded searches nicely... then again, if our
-      // highlighting field is not the one being search on, this makes sense?
-      if ($query_processor->solrDefType == 'dismax' || $query_processor->solrDefType == 'edismax') {
-        $search_results['object_url_fragment'] .= "/search/" . rawurlencode($query_processor->solrQuery);
-      }
-    }
-  }
-}
-
-/**
- * Implements hook_CMODEL_PID_islandora_solr_object_result_alter().
- *
  * Add page viewing fragment and search term to show all search results within
  * book on page load.
  */


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2014

Possibly related to https://jira.duraspace.org/browse/ISLANDORA-2023.

# What does this Pull Request do?

This is a companion PR to https://github.com/Islandora/islandora_internet_archive_bookreader/pull/110.

Moves the hook implementation that rewrites search results for book pages to deep link into the IA Book Reader from the Islandora Book Solution Pack to the Islandora Internet Archive Book Reader module, and adds an additional check to the hook to confirm that the IA Book Reader is the currently configured book viewer.

# What's new?

1. Moved `islandora_book_islandora_pageCModel_islandora_solr_object_result_alter()` to `islandora_internet_archive_bookreader_islandora_pageCModel_islandora_solr_object_result_alter()`.
2. Added check to top of `islandora_internet_archive_bookreader_islandora_pageCModel_islandora_solr_object_result_alter()` to return if the currently configured book viewer is not 'islandora_internet_archive_bookreader'.

# How should this be tested?

Note: This must be tested in conjunction with https://github.com/Islandora/islandora_internet_archive_bookreader/pull/110.

To see current behavior:

* Confirm the current URL rewriting in search results by performing a search that yields some book pages. Links to page objects will contain deep linking into the IA Book Reader (e.g., http://localhost:8000/islandora/object/issue2014%3A6#page/1/mode/1up/search/english%20bay).
* Check out the 7.x branch of both the Islandora IA Bookviewer module and the Islandora Book Solution Pack.
* Visit admin/islandora/solution_pack_config/book and select "None" as the book viewer.
* Clear you cache.
* Perform the same search as above. Links in the search results are still rewritten.
* Disable the islandora_internet_archive_bookreader module.
* Clear you cache.
* Perform the same search as above. Links in the search results are still rewritten.

To test behavior when Islandora IA Bookviewer is not configured as the book viewer:

* Check out the 7.x-ISLANDORA-2014 branch of both the Islandora IA Bookviewer module and the Islandora Book Solution Pack.
* Re-enable the islandora_internet_archive_bookreader module.
* Visit admin/islandora/solution_pack_config/book and select "None" as the book viewer.
* Clear you cache.
* Perform the same search as above. Links in the search results should not be rewritten, they should go to the page object.

To test behavior when Islandora IA Bookviewer is configured as book viewer but module is not enabled:

* Check out the 7.x-ISLANDORA-2014 branch of both the Islandora IA Bookviewer module and the Islandora Book Solution Pack.
* Disable the islandora_internet_archive_bookreader module.
* Clear you cache.
* Perform the same search as above. Links in the search results should not be rewritten, they should go to the page object.

# Interested parties
@Islandora/7-x-1-x-committers, @bgilling
