### PR TITLE
Fix identifier isbn field

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ Select configuration options for page derivatives, Parent Solr Field, and select
 
 Further documentation for this module is available at [our wiki](https://wiki.duraspace.org/display/ISLANDORA/Book+Solution+Pack).
 
+## Known Issues
+
+In August 2018, a bug in the Book MODS ingest form was identified and fixed. The form was set to READ all instances of any MODS identifier element,
+but to CREATE and UPDATE identifiers with the 'type="isbn"' attribute. When editing an object with this form, the form would create a new copy
+of every identifier element regardless of attributes, and save it with the 'type="isbn"' attribute. Any objects edited using this form before the 
+August 2018 fix should be reviewed to ensure their metadata is correct.
+
 ## Troubleshooting/Issues
 
 Having problems or solved a problem? Check out the Islandora google groups for a solution.

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Having problems or solved a problem? Check out the Islandora google groups for a
 
 ### Known issues
 
-* **Islandora Book MODS Form**: In August 2018, a bug in the Book MODS ingest form was identified and fixed. 
+* **Islandora Book MODS Form**: In August 2018, a bug in the Book MODS form was identified and fixed. 
 The form's **ISBN** element was set to READ all instances of any MODS identifier element, but to CREATE identifiers with the 'type="isbn"' attribute. 
-When editing an object with this form, the form would create a new copy of every identifier element regardless of attributes, which may have led useres to remove those identifiers. 
+When editing an object with this form, the form would create a new copy of every identifier element regardless of attributes, which may have led users to remove those identifiers. 
 Any objects edited using this form before the August 2018 fix should be reviewed to ensure their metadata is correct.
 
 ## Maintainers/Sponsors

--- a/README.md
+++ b/README.md
@@ -28,13 +28,6 @@ Select configuration options for page derivatives, Parent Solr Field, and select
 
 Further documentation for this module is available at [our wiki](https://wiki.duraspace.org/display/ISLANDORA/Book+Solution+Pack).
 
-## Known Issues
-
-In August 2018, a bug in the Book MODS ingest form was identified and fixed. The form was set to READ all instances of any MODS identifier element,
-but to CREATE and UPDATE identifiers with the 'type="isbn"' attribute. When editing an object with this form, the form would create a new copy
-of every identifier element regardless of attributes, and save it with the 'type="isbn"' attribute. Any objects edited using this form before the 
-August 2018 fix should be reviewed to ensure their metadata is correct.
-
 ## Troubleshooting/Issues
 
 Having problems or solved a problem? Check out the Islandora google groups for a solution.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Having problems or solved a problem? Check out the Islandora google groups for a
 
 ### Known issues
 
-In August 2018, a bug in the Book MODS ingest form was identified and fixed. The form was set to READ all instances of any MODS identifier element, but to CREATE and UPDATE identifiers with the 'type="isbn"' attribute. 
+* **Islandora Book MODS Form**: In August 2018, a bug in the Book MODS ingest form was identified and fixed. 
+The form's **ISBN** element was set to READ all instances of any MODS identifier element, but to CREATE identifiers with the 'type="isbn"' attribute. 
 When editing an object with this form, the form would create a new copy of every identifier element regardless of attributes, which may have led useres to remove those identifiers. 
 Any objects edited using this form before the August 2018 fix should be reviewed to ensure their metadata is correct.
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Having problems or solved a problem? Check out the Islandora google groups for a
 * [Islandora Group](https://groups.google.com/forum/?hl=en&fromgroups#!forum/islandora)
 * [Islandora Dev Group](https://groups.google.com/forum/?hl=en&fromgroups#!forum/islandora-dev)
 
+### Known issues
+
+In August 2018, a bug in the Book MODS ingest form was identified and fixed. The form was set to READ all instances of any MODS identifier element, but to CREATE and UPDATE identifiers with the 'type="isbn"' attribute. 
+When editing an object with this form, the form would create a new copy of every identifier element regardless of attributes, which may have led useres to remove those identifiers. 
+Any objects edited using this form before the August 2018 fix should be reviewed to ensure their metadata is correct.
+
 ## Maintainers/Sponsors
 Current maintainers:
 

--- a/data/forms/book_form_mods.xml
+++ b/data/forms/book_form_mods.xml
@@ -632,7 +632,7 @@
               <value>&lt;identifier type="isbn"&gt;%value%&lt;/identifier&gt;</value>
             </create>
             <read>
-              <path>mods:identifier</path>
+              <path>mods:identifier[@type='isbn']</path>
               <context>parent</context>
             </read>
             <update>


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2285)

# What does this Pull Request do?

Fixes the issue where a MODS record with an identifier other than ISBN populates the ISBN field because it reads any "identifier" element regardless of type.

# What's new?
Adds the type attribute to the ISBN field's Read section.

# How should this be tested?
Ingest a book object with several different identifier fields (uri, isbn, local, doi, etc.)
Edit the MODS record via the form
Observe repetition of ISBN fields, data all messed up
Check out this branch
Edit the object
Observe the ISBN in its proper place

# Additional Notes:
There are lots more issues with this and other stock forms, but we can deal with those separately.

# Interested parties
@Islandora/7-x-1-x-committers
