### PR TITLE
ISLANDORA-2371: Add book CSS

### DIFF
--- a/islandora_book.info
+++ b/islandora_book.info
@@ -5,6 +5,7 @@ dependencies[] = islandora
 dependencies[] = file
 dependencies[] = islandora_paged_content
 configure = admin/islandora/solution_pack_config/book
+stylesheets[all][] = css/islandora_book.css
 version = 7.x-dev
 core = 7.x
 files[] = tests/islandora_book_ingest_purge.test


### PR DESCRIPTION
**JIRA Ticket**: [\[ISLANDORA-2371\] Islandora Book Solution Pack does not use theme CSS](https://jira.duraspace.org/browse/ISLANDORA-2371)

* Other Relevant Links: n/a

# What does this Pull Request do?

Adds the `islandora_book.css` stylesheet to the info file.

# How should this be tested?

The metadata block for book items will now be styled like the other solution packs.

# Interested parties
@ajstanley, current module maintainer
